### PR TITLE
Add support for Windows USERNAME env variable

### DIFF
--- a/builtin/credential/ldap/cli.go
+++ b/builtin/credential/ldap/cli.go
@@ -107,5 +107,8 @@ func usernameFromEnv() string {
 	if user := os.Getenv("USER"); user != "" {
 		return user
 	}
+	if username := os.Getenv("USERNAME"); username != "" {
+		return username
+	}
 	return ""
 }


### PR DESCRIPTION
Windows stores the user in the USERNAME env variable by default.